### PR TITLE
Use minor version on peerDependencies for webpack

### DIFF
--- a/dashboard-plugin/package.json
+++ b/dashboard-plugin/package.json
@@ -36,7 +36,7 @@
     "node-fetch": "^2.6.0"
   },
   "peerDependencies": {
-    "webpack": "5.45.1",
+    "webpack": "^5.45.1",
     "webpack-sources": "^1.4.3 || ^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
When I tried to install this plugin in my project where I use webpack "5.61.0" I get error: 
"Could not resolve dependency: peer webpack@"5.45.1" from @module-federation/dashboard-plugin@2.3.0"

Suggestion: Use minor prefix for webpack on peerDependencies