### PR TITLE
Add new parameter in plugin to take the right module federation plugin

### DIFF
--- a/dashboard-plugin/README.md
+++ b/dashboard-plugin/README.md
@@ -29,13 +29,14 @@ This will post the `ModuleFederationPlugin` metrics to the update endpoint at `h
 
 There are also other options:
 
-| Key            | Description                                                                             |
-| -------------- | --------------------------------------------------------------------------------------- |
-| dashboardURL   | The URL of the dashboard endpoint.                                                      |
-| metadata       | Any additional metadata you want to apply to this application for use in the dashboard. |
-| filename       | The file path where the dashboard data.                                                 |
-| standalone     | For use without ModuleFederationPlugin                                                  |
-| publishVersion | Used for versioned remotes. '1.0.0' will be used for each remote if not passed          |
+| Key                    | Description                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| dashboardURL           | The URL of the dashboard endpoint.                                                      |
+| metadata               | Any additional metadata you want to apply to this application for use in the dashboard. |
+| filename               | The file path where the dashboard data.                                                 |
+| standalone             | For use without ModuleFederationPlugin                                                  |
+| publishVersion         | Used for versioned remotes. '1.0.0' will be used for each remote if not passed          |
+| moduleFederationFilter | Used for take the right ModuleFederationPlugin                                          |
 
 ## Metadata
 
@@ -68,3 +69,21 @@ You can add whatever keys you want to `metadata`, but there are some keys that t
 This is useful when Module Federation is not used, options can be passed that are usually inferred from Module Federation Options
 
 - `name`: the name of the app, must be unique
+
+## Module Federation filter
+
+This paramater is _optional_ and tis specified as an object.
+
+```js
+plugins: [
+  ...new DashboardPlugin({
+    dashboardURL:
+      "https://federation-dashboard-alpha.vercel.app/api/update?token=writeToken",
+    moduleFederationFilter: {
+      remoteName: "home",
+    },
+  }),
+];
+```
+
+This is useful when you have multiple Module Federation plugins in the webpack config and you take the specific one in the dashboard.

--- a/dashboard-plugin/README.md
+++ b/dashboard-plugin/README.md
@@ -70,7 +70,7 @@ This is useful when Module Federation is not used, options can be passed that ar
 
 - `name`: the name of the app, must be unique
 
-## Module Federation filter
+## Module Federation Filter
 
 This paramater is _optional_ and tis specified as an object.
 
@@ -86,4 +86,4 @@ plugins: [
 ];
 ```
 
-This is useful when you have multiple Module Federation plugins in the webpack config and you take the specific one in the dashboard.
+This is useful when you have multiple Module Federation plugins in the webpack config and you want a specific one in the dashboard.


### PR DESCRIPTION
This new parameter is interesting when you have multiple module federation plugin defined in the webpack config.
When you want push a specific module federation in the dashboard.

Why I add this parameter?
In my company, we start our journey in micro-front end with multi teams. Each team is responsible for a micro app, each of them is deployed individually. We use the concept of app shell that load the micro app. But each micro app need to define the same component / tools than the app shell, like authentication.
This plugin is very interesting to known what is share and who use it.